### PR TITLE
Follow HTTP redirects (max. 5 redirects).

### DIFF
--- a/src/request.cc
+++ b/src/request.cc
@@ -26,6 +26,8 @@ Request::Request ()
     curl_easy_setopt (curl_, CURLOPT_WRITEDATA, &write_buffer_);
     curl_easy_setopt (curl_, CURLOPT_HEADERDATA, &header_buffer_);
     curl_easy_setopt (curl_, CURLOPT_NOSIGNAL, 1);
+    curl_easy_setopt (curl_, CURLOPT_FOLLOWLOCATION, 1);
+    curl_easy_setopt (curl_, CURLOPT_MAXREDIRS, 5);
 }
 
 Request::~Request () {


### PR DESCRIPTION
Request method doesn't follow HTTP redirects, resulting in empty strings. So I set the CURLOPT_FOLLOWLOCATION flag to 1, and set the CURLOPT_MAXREDIRS to 5.
